### PR TITLE
downgraded spacy in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ sklearn>=0.0
 torch>=1.4.0
 scipy>=1.3.1
 gitpython
-spacy>=2.1.3
+spacy>=2.1.3,<3
 joblib>=0.13.2
 python-Levenshtein>=0.12.0
 # https://github.com/pytorch/fairseq/issues/3535


### PR DESCRIPTION
Having spacy > 3 works fine for inference, but seems to cause problems during mining. It was preventing from creating the spacy tokenizer at muss/text.py:278.

```py
import muss.feature_extraction as feat

feat.get_lexical_complexity_score("Un exemple de texte pas trop difficile en français.", "fr")
```

```py
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_1122/3666114828.py in <module>
----> 1 feat.get_lexical_complexity_score("Un exemple de texte pas trop difficile en français.", "fr")

~/code/muss/muss/feature_extraction.py in get_lexical_complexity_score(sentence, language)
     47 # Single sentence feature extractors with signature function(sentence) -> float
     48 def get_lexical_complexity_score(sentence, language='en'):
---> 49     log_ranks = get_log_ranks(sentence, language=language)
     50     if len(log_ranks) == 0:
     51         log_ranks = [np.log(1 + len(get_word2rank()))]  # TODO: This is completely arbitrary

~/code/muss/muss/feature_extraction.py in get_log_ranks(text, language)
     40     return [
     41         get_log_rank(word, language=language)
---> 42         for word in get_content_words(text, language=language)
     43         if word in get_word2rank(language=language)
     44     ]

~/code/muss/muss/text.py in get_content_words(text, language)
    287 
    288 def get_content_words(text, language='en'):
--> 289     return [token.text for token in get_spacy_content_tokens(text, language=language)]
    290 
    291 

~/code/muss/muss/text.py in get_spacy_content_tokens(text, language)
    283         return not token.is_stop and not token.is_punct and token.ent_type_ == ''  # Not named entity
    284 
--> 285     return [token for token in get_spacy_tokenizer(language=language)(text) if is_content_token(token)]
    286 
    287 

~/code/muss/muss/text.py in get_spacy_tokenizer(language)
    276 @lru_cache(maxsize=1)
    277 def get_spacy_tokenizer(language='en'):
--> 278     return get_spacy_model(language=language).Defaults.create_tokenizer(get_spacy_model(language=language))
    279 
    280 

AttributeError: type object 'FrenchDefaults' has no attribute 'create_tokenizer'
```

Avoiding using spacy 3 solved the problem