### PR TITLE
Fix UnicodeEncodeError failures

### DIFF
--- a/muss/preprocessors.py
+++ b/muss/preprocessors.py
@@ -128,7 +128,7 @@ class AbstractPreprocessor(ABC):
         if encoder_filepath is None:
             # We will use an empty temporary file which will yield None for each line
             encoder_filepath = get_temp_filepath(create=True)
-        with open(output_filepath, 'w') as f:
+        with open(output_filepath, 'w', encoding='utf-8') as f:
             for input_line, encoder_line in yield_lines_in_parallel([input_filepath, encoder_filepath], strict=False):
                 f.write(self.encode_sentence(input_line, encoder_line) + '\n')
 
@@ -136,7 +136,7 @@ class AbstractPreprocessor(ABC):
         if encoder_filepath is None:
             # We will use an empty temporary file which will yield None for each line
             encoder_filepath = get_temp_filepath(create=True)
-        with open(output_filepath, 'w') as f:
+        with open(output_filepath, 'w', encoding='utf-8') as f:
             for encoder_sentence, input_sentence in yield_lines_in_parallel(
                 [encoder_filepath, input_filepath], strict=False
             ):

--- a/muss/utils/helpers.py
+++ b/muss/utils/helpers.py
@@ -88,7 +88,7 @@ def run_command(cmd, mute=False):
 def open_files(filepaths, mode='r'):
     files = []
     try:
-        files = [Path(filepath).open(mode) for filepath in filepaths]
+        files = [Path(filepath).open(mode, encoding='utf-8') for filepath in filepaths]
         yield files
     finally:
         [f.close() for f in files]
@@ -134,7 +134,7 @@ def write_lines(lines, filepath=None):
         filepath = get_temp_filepath()
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    with filepath.open('w') as f:
+    with filepath.open('w', encoding='utf-8') as f:
         for line in lines:
             f.write(line + '\n')
     return filepath
@@ -145,7 +145,7 @@ def yield_lines(filepath, gzipped=False, n_lines=None):
     open_function = open
     if gzipped or filepath.name.endswith('.gz'):
         open_function = gzip.open
-    with open_function(filepath, 'rt') as f:
+    with open_function(filepath, 'rt', encoding='utf-8') as f:
         for i, l in enumerate(f):
             if n_lines is not None and i >= n_lines:
                 break
@@ -322,7 +322,7 @@ def mute(mute_stdout=True, mute_stderr=True):
 
 @contextmanager
 def log_std_streams(filepath):
-    log_file = open(filepath, 'w')
+    log_file = open(filepath, 'w', encoding='utf-8')
     try:
         with redirect_streams(source_streams=[sys.stdout], target_streams=[log_file, sys.stdout]):
             with redirect_streams(source_streams=[sys.stderr], target_streams=[log_file, sys.stderr]):

--- a/scripts/simplify.py
+++ b/scripts/simplify.py
@@ -24,8 +24,6 @@ if __name__ == '__main__':
     source_sentences = read_lines(args.filepath)
     pred_sentences = simplify_sentences(source_sentences, model_name=args.model_name)
     for c, s in zip(source_sentences, pred_sentences):
-        s = s.encode('utf-8')
-        c = c.encode('utf-8')
         print('-' * 80)
         print(f'Original:   {c}')
         print(f'Simplified: {s}')

--- a/scripts/simplify.py
+++ b/scripts/simplify.py
@@ -24,6 +24,8 @@ if __name__ == '__main__':
     source_sentences = read_lines(args.filepath)
     pred_sentences = simplify_sentences(source_sentences, model_name=args.model_name)
     for c, s in zip(source_sentences, pred_sentences):
+        s = s.encode('utf-8')
+        c = c.encode('utf-8')
         print('-' * 80)
         print(f'Original:   {c}')
         print(f'Simplified: {s}')

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@
 from setuptools import setup, find_packages
 
 
-with open('README.md', 'r') as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
-with open('requirements.txt', 'r') as f:
+with open('requirements.txt', 'r', encoding='utf-8') as f:
     requirements = f.read().strip().split('\n')
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()
 
-with open('requirements.txt', 'r', encoding='utf-8') as f:
+with open('requirements.txt', 'r') as f:
     requirements = f.read().strip().split('\n')
 
 setup(


### PR DESCRIPTION
Add _encoding='utf-8'_ flag to file streams & strings to avoid "UnicodeEncodeError: 'ascii' codec can't encode character.." errors.