### PR TITLE
Update requirements to use HTTPS instead of Git

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ sacremoses>=0.0.38
 nevergrad>=0.4.0.post3
 editdistance>=0.5.3
 tokenizers>=0.5.2
-easse@ git+git://github.com/feralvam/easse.git
-kenlm@ git+git://github.com/kpu/kenlm.git
+easse@ git+https://github.com/feralvam/easse.git
+kenlm@ git+https://github.com/kpu/kenlm.git
 cachier>=1.2.8


### PR DESCRIPTION
Use HTTPS protocol for requirements because github dropped support for git protocol according to:
https://stackoverflow.com/a/66484318/4255993
https://github.blog/2021-09-01-improving-git-protocol-security-github/

It might be the reason why #35 was created.